### PR TITLE
Added io-Comune thirdparty

### DIFF
--- a/publishers.thirdparty.yml
+++ b/publishers.thirdparty.yml
@@ -158,3 +158,7 @@
 - name: "Mindicity"
   repos:
     - "https://gitlab-di.mindicity.it/mindicity/core/ui/mindicity.core.ui.app"
+    
+- name: "io-Comune: il tema di Plone per la Pubblica Amministrazione"
+  repos:
+    - "https://github.com/italia/design-comuni-plone-theme"


### PR DESCRIPTION
io-Comune è un tema per il CMS open source Plone conforme alle nuove linee guida AgID (PNRR) per i Comuni ed Enti pubblici.