### PR TITLE
feat: create Software even if publiccode.yml is invalid

### DIFF
--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -217,12 +217,13 @@ func (c ApiClient) GetSoftwareByURL(url string) (*Software, error) {
 }
 
 // PostSoftware creates a new software resource with the given fields and returns
-// an http.Response and any error encountered.
-func (c ApiClient) PostSoftware(url string, aliases []string, publiccodeYml string) (*http.Response, error) {
+// an XXX http.Response and any error encountered.
+func (c ApiClient) PostSoftware(url string, aliases []string, publiccodeYml string, active bool) (*Software, error) {
 	body, err := json.Marshal(map[string]interface{}{
 		"publiccodeYml": publiccodeYml,
 		"url":           url,
 		"aliases":       aliases,
+		"active":        active,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("can't create software: %w", err)
@@ -230,14 +231,20 @@ func (c ApiClient) PostSoftware(url string, aliases []string, publiccodeYml stri
 
 	res, err := c.Post(joinPath(c.baseURL, "/software"), body)
 	if err != nil {
-		return res, fmt.Errorf("can't create software: %w", err)
+		return nil, fmt.Errorf("can't create software: %w", err)
 	}
 
 	if res.StatusCode < 200 || res.StatusCode > 299 {
-		return res, fmt.Errorf("can't create software: API replied with HTTP %s", res.Status)
+		return nil, fmt.Errorf("can't create software: API replied with HTTP %s", res.Status)
 	}
 
-	return res, nil
+	postSoftwareResponse := &Software{}
+	err = json.NewDecoder(res.Body).Decode(&postSoftwareResponse)
+	if err != nil {
+		return nil, fmt.Errorf("can't parse POST /software (for %s) response: %w", url, err)
+	}
+
+	return postSoftwareResponse, nil
 }
 
 // PatchSoftware updates a software resource with the given fields and returns


### PR DESCRIPTION
Previously we only created a new Software entity only when the
publiccode.yml is valid, so in case of a new repo with an invalid
publiccode.yml nothing was added.

This means the new software didn't exist from the API's point of view,
and because of that publiccode-issueopener can't notify the maintainers about
the errors, even if new repos are arguably the ones where error reporting and
a little hand holding are more valuable.

So add the software even if publiccode.yml is invalid, setting active to
false.

We will re-activate software whenever publiccode.yml is valid *only*
if it was previously added automatically for the first time as inactive.

Fix #325.