### PR TITLE
fix: properly get all the Publishers

### DIFF
--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -125,6 +125,7 @@ func (c ApiClient) GetPublishers() ([]common.Publisher, error) {
 	var publishersResponse *PublishersPaginated
 
 	pageAfter := ""
+	publishers := make([]common.Publisher, 0, 25)
 
 page:
 	reqUrl := joinPath(c.baseURL, "/publishers") + pageAfter
@@ -146,7 +147,6 @@ page:
 		return nil, fmt.Errorf("can't parse GET %s response: %w", reqUrl, err)
 	}
 
-	publishers := make([]common.Publisher, 0, len(publishersResponse.Data))
 	for _, p := range publishersResponse.Data {
 		var groups, repos []internalUrl.URL
 


### PR DESCRIPTION
Fix the bug introduced in 0e4e25c01405 that returned only the first 10 Publishers.