### PR TITLE
feat: get publishers files on run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,6 @@ COPY start.sh .
 COPY vitality-ranges.yml .
 COPY wait-for-it.sh .
 
-RUN wget https://raw.githubusercontent.com/italia/developers.italia.it/HEAD/_data/publishers.thirdparty.yml
-RUN wget https://raw.githubusercontent.com/italia/developers.italia.it/HEAD/_data/publishers.yml
-
 # Run as unprivileged user
 RUN adduser --home ${HOME} --shell /bin/sh --disabled-password ${USER}
 

--- a/start.sh
+++ b/start.sh
@@ -2,4 +2,7 @@
 
 bin/crawler updateipa
 bin/crawler download-publishers https://onboarding.developers.italia.it/repo-list publishers.onboarding.yml
+wget https://raw.githubusercontent.com/italia/developers.italia.it/HEAD/_data/publishers.thirdparty.yml
+wget https://raw.githubusercontent.com/italia/developers.italia.it/HEAD/_data/publishers.yml
+
 bin/crawler crawl publishers*.yml


### PR DESCRIPTION
Get publishers on run instead of in the build of the Docker image, so every run is up to date with the current publishers.