### PR TITLE
refactor: add constant and disable the gomnd linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -103,7 +103,6 @@ linters:
     - gofumpt
     - goheader
     - goimports
-    # - gomnd
     - gomoddirectives
     - gomodguard
     - goprintffuncname
@@ -168,6 +167,9 @@ linters:
     # # https://github.com/italia/developers-italia-api/issues/190)
     # # Don't feel about chasing this one down
     # - musttag
+
+    # More false positive than actual issues
+    - gomnd
 
   # Run only fast linters from enabled linters set (first run won't be fast)
   # Default: false

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -44,6 +44,7 @@ type Crawler struct {
 // NewCrawler initializes a new Crawler object and connects to Elasticsearch (if dryRun == false).
 func NewCrawler(dryRun bool) *Crawler {
 	var c Crawler
+	const channelSize = 1000
 
 	c.DryRun = dryRun
 
@@ -53,7 +54,7 @@ func NewCrawler(dryRun bool) *Crawler {
 	}
 
 	// Initiate a channel of repositories.
-	c.repositories = make(chan common.Repository, 1000)
+	c.repositories = make(chan common.Repository, channelSize)
 
 	// Register Prometheus metrics.
 	metrics.RegisterPrometheusCounter("repository_processed", "Number of repository processed.", c.Index)


### PR DESCRIPTION
Add gomnd to the list of disabled linters because it the majority of issues it catches are not really issues.