### PR TITLE
chore(release): pin goreleaser to v1.18.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v1.18.2
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
archives.replacements was removed in 1.19.0:
https://goreleaser.com/deprecations/#archivesreplacements.

That should've probably been a new major version on goreleaser's side.

(see also https://github.com/pulumi/pulumi/issues/13312)