### PR TITLE
ci: pin actions to commit SHAs and restrict permissions

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -2,13 +2,18 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 22 * * *'
+
+permissions: {}
+
 jobs:
   crawl:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     container:
       image: italia/publiccode-crawler:latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: publiccode-crawler crawl
         env:
           CRAWLER_DATADIR: /tmp/data

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,18 @@
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   go-lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25"
-      - uses: golangci/golangci-lint-action@v9.2.0
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.11.3
           args: --timeout 3m

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -3,19 +3,20 @@ on:
     tags:
       - helm/*
 
-permissions:
-  packages: write
+permissions: {}
 
 jobs:
   release_chart:
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Get version
         id: get_version
         run: echo "version=${GITHUB_REF_NAME#helm/}" >> $GITHUB_ENV
       - name: Push chart to GitHub Container Registry
-        uses: appany/helm-oci-chart-releaser@v0.5.0
+        uses: appany/helm-oci-chart-releaser@d94988c92bed2e09c6113981f15f8bb495d10943 # v0.5.0
         with:
           name: publiccode-crawler
           repository: ${{ github.repository }}/charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,24 +5,25 @@ on:
     tags:
       - '*'
 
+permissions: {}
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      -
-        name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25'
         id: go
-      -
-        name: Checkout
-        uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           version: v2.15.2
           args: release --clean

--- a/.github/workflows/test_and_publish_docker_image.yml
+++ b/.github/workflows/test_and_publish_docker_image.yml
@@ -6,16 +6,20 @@ on:
 
 name: ci
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # The build job will use the .git directory to
           # infer the current version to embed in the binary
           fetch-depth: 0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25'
       - run: go build
@@ -25,11 +29,13 @@ jobs:
     needs: test
 
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
 
     if: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -45,7 +51,7 @@ jobs:
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           build-args: |
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1


### PR DESCRIPTION
Actions pinned to mutable tags are vulnerable to tag-moving supply chain attacks.

- Pin all actions to their current commit SHA (tag kept as comment)
- Add `permissions: {}` at workflow level and grant minimum scopes per job
  - crawl: `contents: read`
  - lint: `contents: read`
  - release-chart: `packages: write`
  - release: `contents: write`
  - test_and_publish_docker_image: `contents: read` for test, `packages: write` for build/push