### PR TITLE
fix: repos with invalid publiccode.yml were not saved

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -381,17 +381,13 @@ func (c *Crawler) ProcessRepo(repository common.Repository) { //nolint:maintidx
 		}
 	}
 
-	if !valid {
+	if valid {
+		logEntries = append(logEntries, fmt.Sprintf("[%s] GOOD publiccode.yml\n", repository.Name))
+		metrics.GetCounter("repository_good_publiccodeyml", c.Index).Inc()
+	} else {
 		logEntries = append(logEntries, fmt.Sprintf("[%s] BAD publiccode.yml: %+v\n", repository.Name, err))
-
 		metrics.GetCounter("repository_bad_publiccodeyml", c.Index).Inc()
-
-		return
 	}
-
-	logEntries = append(logEntries, fmt.Sprintf("[%s] GOOD publiccode.yml\n", repository.Name))
-
-	metrics.GetCounter("repository_good_publiccodeyml", c.Index).Inc()
 
 	if c.DryRun {
 		log.Infof("[%s]: Skipping other steps (--dry-run)", repository.Name)


### PR DESCRIPTION
The early return added in #397 skipped PostSoftware, so repos with invalid publiccode.yml stopped being created in the API. That path was introduced in #339 specifically so publiccode-issueopener can notify maintainers. Restore the if/else so PostSoftware runs with active=valid.