### PR TITLE
fix: nil pointer panic when publiccode.yml fails to parse

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -404,11 +404,15 @@ func (c *Crawler) ProcessRepo(repository common.Repository) { //nolint:maintidx
 		aliases = append(aliases, repository.URL.String())
 	}
 
-	publiccodeYml, err := parsed.ToYAML()
-	if err != nil {
-		logEntries = append(logEntries, fmt.Sprintf("[%s] parsing error: %s", repository.Name, err.Error()))
+	var publiccodeYml []byte
 
-		return
+	if parsed != nil {
+		publiccodeYml, err = parsed.ToYAML()
+		if err != nil {
+			logEntries = append(logEntries, fmt.Sprintf("[%s] parsing error: %s", repository.Name, err.Error()))
+
+			return
+		}
 	}
 
 	if software == nil {


### PR DESCRIPTION
When parser.Parse fails with a non-validation error, parsed is nil. Calling ToYAML on nil panics. Skip ToYAML and use empty string for the publiccodeYml payload in that case.