### PR TITLE
ci: enable goconst, tagliatelle, gocyclo, funlen, varnamelen, nestif linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -53,13 +53,7 @@ linters:
 
     # TODO: fix and enable these
     - cyclop
-    - funlen
     - gocognit
-    - goconst
-    - nestif
-    - tagliatelle
-    - varnamelen
-    - gocyclo
 
   settings:
     lll:

--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -148,23 +148,23 @@ page:
 		return nil, fmt.Errorf("can't parse GET %s response: %w", reqURL, err)
 	}
 
-	for _, p := range publishersResponse.Data {
+	for _, pub := range publishersResponse.Data {
 		var groups, repos []internalUrl.URL
 
-		for _, codeHosting := range p.CodeHostings {
-			u, err := url.Parse(codeHosting.URL)
+		for _, codeHosting := range pub.CodeHostings {
+			parsedURL, err := url.Parse(codeHosting.URL)
 			if err != nil {
 				return nil, fmt.Errorf("can't parse GET %s response: %w", reqURL, err)
 			}
 
 			if codeHosting.Group {
-				groups = append(groups, (internalUrl.URL)(*u))
+				groups = append(groups, (internalUrl.URL)(*parsedURL))
 			} else {
-				repos = append(repos, (internalUrl.URL)(*u))
+				repos = append(repos, (internalUrl.URL)(*parsedURL))
 			}
 		}
 
-		id := p.ID
+		publisherID := pub.ID
 
 		// Let's give precedence to the alternativeId. It's usually set by
 		// at Publisher creation and it's supposed to be more representative of the
@@ -173,13 +173,13 @@ page:
 		//
 		// This way, we also take a minimalist approach to Publisher concept in the crawler,
 		// having just one id.
-		if p.AlternativeID != "" {
-			id = p.AlternativeID
+		if pub.AlternativeID != "" {
+			publisherID = pub.AlternativeID
 		}
 
 		publishers = append(publishers, common.Publisher{
-			ID:            id,
-			Name:          fmt.Sprintf("%s %s", p.Description, p.Email),
+			ID:            publisherID,
+			Name:          fmt.Sprintf("%s %s", pub.Description, pub.Email),
 			Organizations: groups,
 			Repositories:  repos,
 		})
@@ -195,26 +195,26 @@ page:
 }
 
 // GetSoftware returns the software with the given id or any error encountered.
-func (clt APIClient) GetSoftware(id string) (*Software, error) {
+func (clt APIClient) GetSoftware(softwareID string) (*Software, error) {
 	var softwareResponse Software
 
-	url := joinPath(clt.baseURL, "/software") + "/" + id
+	url := joinPath(clt.baseURL, "/software") + "/" + softwareID
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("can't GET /software/%s: %w", id, err)
+		return nil, fmt.Errorf("can't GET /software/%s: %w", softwareID, err)
 	}
 
 	res, err := clt.retryableClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("can't GET /software/%s: %w", id, err)
+		return nil, fmt.Errorf("can't GET /software/%s: %w", softwareID, err)
 	}
 
 	defer res.Body.Close()
 
 	err = json.NewDecoder(res.Body).Decode(&softwareResponse)
 	if err != nil {
-		return nil, fmt.Errorf("can't parse GET /software/%s response: %w", id, err)
+		return nil, fmt.Errorf("can't parse GET /software/%s response: %w", softwareID, err)
 	}
 
 	return &softwareResponse, nil
@@ -289,7 +289,7 @@ func (clt APIClient) PostSoftware(url string, aliases []string, publiccodeYml st
 // PatchSoftware updates a software resource with the given fields and returns
 // any error encountered.
 func (clt APIClient) PatchSoftware(
-	id string, url string, aliases []string, publiccodeYml string,
+	softwareID string, url string, aliases []string, publiccodeYml string,
 ) error {
 	body, err := json.Marshal(map[string]any{
 		"publiccodeYml": publiccodeYml,
@@ -300,7 +300,7 @@ func (clt APIClient) PatchSoftware(
 		return fmt.Errorf("can't update software: %w", err)
 	}
 
-	res, err := clt.Patch(joinPath(clt.baseURL, "/software/"+id), body)
+	res, err := clt.Patch(joinPath(clt.baseURL, "/software/"+softwareID), body)
 	if err != nil {
 		return fmt.Errorf("can't update software: %w", err)
 	}
@@ -362,14 +362,14 @@ func (clt APIClient) PostLog(message string) error {
 }
 
 func joinPath(base string, paths ...string) string {
-	u, err := url.Parse(base)
+	parsedURL, err := url.Parse(base)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	for _, p := range paths {
-		u.Path = path.Join(u.Path, p)
+		parsedURL.Path = path.Join(parsedURL.Path, p)
 	}
 
-	return u.String()
+	return parsedURL.String()
 }

--- a/cmd/crawl-software.go
+++ b/cmd/crawl-software.go
@@ -30,13 +30,13 @@ Crawl a single software given its API id and its publisher.`,
 			log.Fatal("Please set GITHUB_TOKEN, it's needed to use the GitHub API'")
 		}
 
-		c := crawler.NewCrawler(dryRun)
+		crwlr := crawler.NewCrawler(dryRun)
 
 		publisher := common.Publisher{
 			ID: args[1],
 		}
 
-		if err := c.CrawlSoftwareByID(args[0], publisher); err != nil {
+		if err := crwlr.CrawlSoftwareByID(args[0], publisher); err != nil {
 			log.Fatal(err)
 		}
 	},

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -38,7 +38,7 @@ crawl directory/*.yml`,
 			log.Fatal("Please set GITHUB_TOKEN, it's needed to use the GitHub API'")
 		}
 
-		c := crawler.NewCrawler(dryRun)
+		crwlr := crawler.NewCrawler(dryRun)
 
 		var publishers []common.Publisher
 
@@ -62,7 +62,7 @@ crawl directory/*.yml`,
 			}
 		}
 
-		if err := c.CrawlPublishers(publishers); err != nil {
+		if err := crwlr.CrawlPublishers(publishers); err != nil {
 			log.Fatal(err)
 		}
 	},

--- a/cmd/download_publishers.go
+++ b/cmd/download_publishers.go
@@ -58,37 +58,37 @@ var downloadPublishersCmd = &cobra.Command{
 		}
 
 	REPOLIST:
-		for _, i := range repolist.Registrati {
+		for _, entry := range repolist.Registrati {
 			for idx, publisher := range publishers {
-				if publisher.ID == i.IPA {
-					u, _ := url.Parse(i.URL)
+				if publisher.ID == entry.IPA {
+					parsedURL, _ := url.Parse(entry.URL)
 					// If this Id is already known, append this URL to the existing item
-					publishers[idx].Organizations = append(publisher.Organizations, (ymlurl.URL)(*u))
+					publishers[idx].Organizations = append(publisher.Organizations, (ymlurl.URL)(*parsedURL))
 
 					continue REPOLIST
 				}
 			}
 
-			u, _ := url.Parse(i.URL)
+			parsedURL, _ := url.Parse(entry.URL)
 			// If this IPA code is not known, append a new publisher item
 			publishers = append(publishers, common.Publisher{
-				Name:          i.IPA,
-				ID:            i.IPA,
-				Organizations: []ymlurl.URL{(ymlurl.URL)(*u)},
+				Name:          entry.IPA,
+				ID:            entry.IPA,
+				Organizations: []ymlurl.URL{(ymlurl.URL)(*parsedURL)},
 			})
 		}
 
 		// Write to the destination file
-		f, err := os.Create(args[1])
+		outFile, err := os.Create(args[1])
 		if err != nil {
 			log.Fatal(err)
 		}
-		defer f.Close()
+		defer outFile.Close()
 		data, err := yaml.Marshal(publishers)
 		if err != nil {
 			log.Fatal(err)
 		}
-		if _, err = f.Write(data); err != nil {
+		if _, err = outFile.Write(data); err != nil {
 			log.Fatal(err)
 		}
 	},

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -46,11 +46,11 @@ type Crawler struct {
 
 // NewCrawler initializes a new Crawler object and connects to Elasticsearch (if dryRun == false).
 func NewCrawler(dryRun bool) *Crawler {
-	var c Crawler
+	var crwlr Crawler
 
 	const channelSize = 1000
 
-	c.DryRun = dryRun
+	crwlr.DryRun = dryRun
 
 	datadir := viper.GetString("DATADIR")
 	if err := os.MkdirAll(datadir, 0o744); err != nil {
@@ -58,59 +58,59 @@ func NewCrawler(dryRun bool) *Crawler {
 	}
 
 	// Initiate a channel of repositories.
-	c.repositories = make(chan common.Repository, channelSize)
+	crwlr.repositories = make(chan common.Repository, channelSize)
 
 	// Register Prometheus metrics.
-	metrics.RegisterPrometheusCounter("repository_processed", "Number of repository processed.", c.Index)
+	metrics.RegisterPrometheusCounter("repository_processed", "Number of repository processed.", crwlr.Index)
 	metrics.RegisterPrometheusCounter(
 		"repository_good_publiccodeyml", "Number of valid publiccode.yml files in the processed repos.",
-		c.Index,
+		crwlr.Index,
 	)
 	metrics.RegisterPrometheusCounter(
 		"repository_bad_publiccodeyml", "Number of invalid publiccode.yml files in the processed repos.",
-		c.Index,
+		crwlr.Index,
 	)
-	metrics.RegisterPrometheusCounter("repository_cloned", "Number of repository cloned", c.Index)
-	metrics.RegisterPrometheusCounter("repository_new", "Number of new repositories", c.Index)
-	metrics.RegisterPrometheusCounter("repository_known", "Number of already known repositories", c.Index)
+	metrics.RegisterPrometheusCounter("repository_cloned", "Number of repository cloned", crwlr.Index)
+	metrics.RegisterPrometheusCounter("repository_new", "Number of new repositories", crwlr.Index)
+	metrics.RegisterPrometheusCounter("repository_known", "Number of already known repositories", crwlr.Index)
 	metrics.RegisterPrometheusCounter(
 		"repository_upsert_failures", "Number of failures in creating or updating software in the API",
-		c.Index,
+		crwlr.Index,
 	)
 	metrics.RegisterPrometheusCounter(
 		"repository_fetch_failed", "Number of repositories where fetching publiccode.yml failed (non-404)",
-		c.Index,
+		crwlr.Index,
 	)
 
-	c.gitHubScanner = scanner.NewGitHubScanner()
-	c.gitLabScanner = scanner.NewGitLabScanner()
-	c.bitBucketScanner = scanner.NewBitBucketScanner()
-	c.giteaScanner = scanner.NewGiteaScanner()
+	crwlr.gitHubScanner = scanner.NewGitHubScanner()
+	crwlr.gitLabScanner = scanner.NewGitLabScanner()
+	crwlr.bitBucketScanner = scanner.NewBitBucketScanner()
+	crwlr.giteaScanner = scanner.NewGiteaScanner()
 
-	c.apiClient = apiclient.NewClient()
+	crwlr.apiClient = apiclient.NewClient()
 
-	return &c
+	return &crwlr
 }
 
 // CrawlSoftwareByID crawls a single software.
 func (c *Crawler) CrawlSoftwareByID(software string, publisher common.Publisher) error {
-	var id string
+	var softwareID string
 
 	softwareURL, err := url.Parse(software)
 	if err != nil {
-		id = software
+		softwareID = software
 	} else {
-		id = path.Base(softwareURL.Path)
+		softwareID = path.Base(softwareURL.Path)
 	}
 
-	s, err := c.apiClient.GetSoftware(id)
+	softwareData, err := c.apiClient.GetSoftware(softwareID)
 	if err != nil {
 		return err
 	}
 
-	s.URL = strings.TrimSuffix(s.URL, ".git")
+	softwareData.URL = strings.TrimSuffix(softwareData.URL, ".git")
 
-	repoURL, err := url.Parse(s.URL)
+	repoURL, err := url.Parse(softwareData.URL)
 	if err != nil {
 		return err
 	}
@@ -181,8 +181,8 @@ func (c *Crawler) ScanPublisher(publisher common.Publisher) {
 
 	var err error
 
-	for _, u := range publisher.Organizations { //nolint:dupl
-		orgURL := (url.URL)(u)
+	for _, orgEntry := range publisher.Organizations { //nolint:dupl
+		orgURL := (url.URL)(orgEntry)
 
 		switch {
 		case vcsurl.IsGitHub(&orgURL):
@@ -197,7 +197,7 @@ func (c *Crawler) ScanPublisher(publisher common.Publisher) {
 			err = fmt.Errorf(
 				"publisher %s: unsupported code hosting platform for %s",
 				publisher.Name,
-				u.String(),
+				orgEntry.String(),
 			)
 		}
 
@@ -210,8 +210,8 @@ func (c *Crawler) ScanPublisher(publisher common.Publisher) {
 		}
 	}
 
-	for _, u := range publisher.Repositories { //nolint:dupl
-		repoURL := (url.URL)(u)
+	for _, repoEntry := range publisher.Repositories { //nolint:dupl
+		repoURL := (url.URL)(repoEntry)
 
 		switch {
 		case vcsurl.IsGitHub(&repoURL):
@@ -226,7 +226,7 @@ func (c *Crawler) ScanPublisher(publisher common.Publisher) {
 			err = fmt.Errorf(
 				"publisher %s: unsupported code hosting platform for %s",
 				publisher.Name,
-				u.String(),
+				repoEntry.String(),
 			)
 		}
 
@@ -251,7 +251,7 @@ func (c *Crawler) ProcessRepositories(repos chan common.Repository) {
 }
 
 // ProcessRepo looks for a publiccode.yml file in a repository, and if found it processes it.
-func (c *Crawler) ProcessRepo(repository common.Repository) { //nolint:maintidx
+func (c *Crawler) ProcessRepo(repository common.Repository) { //nolint:funlen,gocyclo
 	var logEntries []string
 
 	var software *apiclient.Software
@@ -415,37 +415,7 @@ func (c *Crawler) ProcessRepo(repository common.Repository) { //nolint:maintidx
 		}
 	}
 
-	if software == nil {
-		// New software to add
-		metrics.GetCounter("repository_new", c.Index).Inc()
-
-		if !c.DryRun {
-			// Add the software even if publiccode.yml is invalid, setting active to
-			// false so that we know about the new software and for example
-			// [publiccode-issueopener](https://github.com/italia/publiccode-issueopener) can
-			// notify maintainers about the errors.
-			active := valid
-
-			software, err = c.apiClient.PostSoftware(url, aliases, string(publiccodeYml), active)
-			if err != nil {
-				return
-			}
-		}
-	} else {
-		// Known software
-		for _, alias := range software.Aliases {
-			if !slices.Contains(aliases, alias) {
-				aliases = append(aliases, alias)
-			}
-		}
-
-		metrics.GetCounter("repository_known", c.Index).Inc()
-
-		if !c.DryRun {
-			err = c.apiClient.PatchSoftware(software.ID, url, aliases, string(publiccodeYml))
-		}
-	}
-
+	err = c.upsertSoftware(software, url, aliases, publiccodeYml, valid)
 	if err != nil {
 		logEntries = append(logEntries, fmt.Sprintf("[%s]: %s", repository.Name, err.Error()))
 
@@ -492,13 +462,13 @@ func (c *Crawler) crawl() error {
 	log.Debugf("CPUs #: %d", numCPUs)
 
 	// Process the repositories in order to retrieve the files.
-	for i := range numCPUs {
+	for idx := range numCPUs {
 		c.repositoriesWg.Add(1)
 
-		go func(id int) {
-			log.Debugf("Starting ProcessRepositories() goroutine (#%d)", id)
+		go func(workerID int) {
+			log.Debugf("Starting ProcessRepositories() goroutine (#%d)", workerID)
 			c.ProcessRepositories(reposChan)
-		}(i)
+		}(idx)
 	}
 
 	for repo := range c.repositories {
@@ -593,4 +563,52 @@ func validateFile(publisher common.Publisher, parsed publiccode.PublicCodeV0, fi
 	}
 
 	return nil
+}
+
+// upsertSoftware posts or patches a software entry depending on whether it already exists.
+func (c *Crawler) upsertSoftware(
+	software *apiclient.Software,
+	repoURL string,
+	aliases []string,
+	publiccodeYml []byte,
+	valid bool,
+) error {
+	if software == nil {
+		// New software to add.
+		metrics.GetCounter("repository_new", c.Index).Inc()
+
+		if c.DryRun {
+			return nil
+		}
+
+		// Add the software even if publiccode.yml is invalid, setting active to
+		// false so that we know about the new software and for example
+		// [publiccode-issueopener](https://github.com/italia/publiccode-issueopener) can
+		// notify maintainers about the errors.
+		_, err := c.apiClient.PostSoftware(repoURL, aliases, string(publiccodeYml), valid)
+
+		return err
+	}
+
+	// Known software: merge any aliases from the API that we don't already have.
+	aliases = mergeNewAliases(aliases, software.Aliases)
+
+	metrics.GetCounter("repository_known", c.Index).Inc()
+
+	if !c.DryRun {
+		return c.apiClient.PatchSoftware(software.ID, repoURL, aliases, string(publiccodeYml))
+	}
+
+	return nil
+}
+
+// mergeNewAliases appends aliases from newAliases that are not already in existing.
+func mergeNewAliases(existing, newAliases []string) []string {
+	for _, alias := range newAliases {
+		if !slices.Contains(existing, alias) {
+			existing = append(existing, alias)
+		}
+	}
+
+	return existing
 }

--- a/git/repo_activity.go
+++ b/git/repo_activity.go
@@ -58,7 +58,7 @@ func CalculateRepoActivity(repository common.Repository, days int, now time.Time
 	)
 
 	// Open and load the git repo path.
-	r, err := git.PlainOpen(path)
+	gitRepo, err := git.PlainOpen(path)
 	if err != nil {
 		log.Error(err)
 
@@ -66,7 +66,7 @@ func CalculateRepoActivity(repository common.Repository, days int, now time.Time
 	}
 
 	// Extract all the commits.
-	commits, err := extractAllCommits(r)
+	commits, err := extractAllCommits(gitRepo)
 	if err != nil {
 		log.Error(err)
 	}
@@ -78,7 +78,7 @@ func CalculateRepoActivity(repository common.Repository, days int, now time.Time
 	commitsPerDay := extractCommitsPerDay(days, commits, now)
 
 	// Extract all tags.
-	tags, err := extractAllTagsCommit(r)
+	tags, err := extractAllTagsCommit(gitRepo)
 	if err != nil {
 		log.Error(err)
 	}
@@ -90,23 +90,23 @@ func CalculateRepoActivity(repository common.Repository, days int, now time.Time
 	vitalityIndex := map[int]float64{}
 
 	// Longevity is the repository age.
-	longevity, err = calculateLongevityIndex(r, now)
+	longevity, err = calculateLongevityIndex(gitRepo, now)
 	if err != nil {
 		log.Warn(err)
 	}
 
-	for i := range days {
-		userCommunity = ranges("userCommunity", userCommunityLastDays(commitsLastDays[i]))
+	for idx := range days {
+		userCommunity = ranges("userCommunity", userCommunityLastDays(commitsLastDays[idx]))
 
-		codeActivity = ranges("codeActivity", activityLastDays(commitsPerDay[i]))
-		releaseHistory = ranges("releaseHistory", releaseHistoryLastDays(tagsPerDays[i]))
+		codeActivity = ranges("codeActivity", activityLastDays(commitsPerDay[idx]))
+		releaseHistory = ranges("releaseHistory", releaseHistoryLastDays(tagsPerDays[idx]))
 
 		repoActivity = userCommunity + codeActivity + releaseHistory + ranges("longevity", longevity)
 		if repoActivity > 100 {
 			repoActivity = 100
 		}
 
-		vitalityIndex[i] = repoActivity
+		vitalityIndex[idx] = repoActivity
 	}
 
 	vitalityIndexTotal := meanActivity(vitalityIndex)
@@ -149,17 +149,17 @@ func releaseHistoryLastDays(tags []*object.Commit) float64 {
 }
 
 // Extract all commits referred to released Tags.
-func extractAllTagsCommit(r *git.Repository) ([]*object.Commit, error) {
+func extractAllTagsCommit(repo *git.Repository) ([]*object.Commit, error) {
 	var allTags []*object.Commit
 
-	tagrefs, err := r.Tags()
+	tagrefs, err := repo.Tags()
 	if err != nil {
 		return nil, err
 	}
 
 	err = tagrefs.ForEach(func(t *plumbing.Reference) error {
 		if !t.Hash().IsZero() {
-			tagObject, _ := r.CommitObject(t.Hash())
+			tagObject, _ := repo.CommitObject(t.Hash())
 			allTags = append(allTags, tagObject)
 		}
 
@@ -173,17 +173,17 @@ func extractAllTagsCommit(r *git.Repository) ([]*object.Commit, error) {
 }
 
 // extractAllCommits returns a slice of all the commits from the passed repository.
-func extractAllCommits(r *git.Repository) ([]*object.Commit, error) {
+func extractAllCommits(repo *git.Repository) ([]*object.Commit, error) {
 	var commits []*object.Commit
 
-	ref, err := r.Head()
+	ref, err := repo.Head()
 	if err != nil {
 		log.Error(err)
 
 		return nil, err
 	}
 
-	cIter, err := r.Log(&git.LogOptions{From: ref.Hash()})
+	cIter, err := repo.Log(&git.LogOptions{From: ref.Hash()})
 	if err != nil {
 		log.Error(err)
 
@@ -202,15 +202,15 @@ func extractAllCommits(r *git.Repository) ([]*object.Commit, error) {
 	return commits, nil
 }
 
-func calculateLongevityIndex(r *git.Repository, now time.Time) (float64, error) {
-	ref, err := r.Head()
+func calculateLongevityIndex(repo *git.Repository, now time.Time) (float64, error) {
+	ref, err := repo.Head()
 	if err != nil {
 		log.Error(err)
 
 		return 0, err
 	}
 
-	cIter, err := r.Log(&git.LogOptions{From: ref.Hash()})
+	cIter, err := repo.Log(&git.LogOptions{From: ref.Hash()})
 	if err != nil {
 		log.Error(err)
 
@@ -253,19 +253,19 @@ func ranges(name string, value float64) float64 {
 		log.Error(err)
 	}
 	// Prepare the data structure for load.
-	t := RangesData{}
+	rangesData := RangesData{}
 	// Populate the yaml.
-	err = yaml.Unmarshal(data, &t)
+	err = yaml.Unmarshal(data, &rangesData)
 	if err != nil {
 		log.Errorf("error: %v", err)
 	}
 
-	for _, v := range t {
+	for _, v := range rangesData {
 		// Select the right ranges table.
 		if v.Name == name {
-			for _, r := range v.Ranges {
-				if value >= r.Min && value < r.Max {
-					return r.Points
+			for _, rangeEntry := range v.Ranges {
+				if value >= rangeEntry.Min && value < rangeEntry.Max {
+					return rangeEntry.Points
 				}
 			}
 		}
@@ -278,12 +278,12 @@ func ranges(name string, value float64) float64 {
 func extractCommitsLastDays(days int, commits []*object.Commit, now time.Time) map[int][]*object.Commit {
 	commitsLastDays := map[int][]*object.Commit{}
 	// Populate the slice of commits in every day.
-	for i := range days {
-		lastDays := now.AddDate(0, 0, -i)
+	for idx := range days {
+		lastDays := now.AddDate(0, 0, -idx)
 		// Append all the commits created before lastDays date.
 		for _, c := range commits {
 			if c.Author.When.Before(lastDays) {
-				commitsLastDays[i] = append(commitsLastDays[i], c)
+				commitsLastDays[idx] = append(commitsLastDays[idx], c)
 			}
 		}
 	}
@@ -295,14 +295,14 @@ func extractCommitsLastDays(days int, commits []*object.Commit, now time.Time) m
 func extractCommitsPerDay(days int, commits []*object.Commit, now time.Time) map[int][]*object.Commit {
 	commitsPerDay := map[int][]*object.Commit{}
 	// Populate the slice of commits in every day.
-	for i := range days {
-		lastDays := now.AddDate(0, 0, -i)
+	for idx := range days {
+		lastDays := now.AddDate(0, 0, -idx)
 		// Append all the commits created before lastDays date.
 		for _, c := range commits {
 			if c.Author.When.Day() == lastDays.Day() &&
 				c.Author.When.Month() == lastDays.Month() && c.Author.When.Year() ==
 				lastDays.Year() {
-				commitsPerDay[i] = append(commitsPerDay[i], c)
+				commitsPerDay[idx] = append(commitsPerDay[idx], c)
 			}
 		}
 	}
@@ -314,15 +314,15 @@ func extractCommitsPerDay(days int, commits []*object.Commit, now time.Time) map
 func extractTagsPerDay(days int, tags []*object.Commit, now time.Time) map[int][]*object.Commit {
 	tagsPerDays := map[int][]*object.Commit{}
 
-	for i := range days {
-		lastDays := now.AddDate(0, 0, -i)
+	for idx := range days {
+		lastDays := now.AddDate(0, 0, -idx)
 		// Append all the commits created before lastDays date.
-		for _, t := range tags {
-			if t != nil {
-				if t.Author.When.Day() == lastDays.Day() &&
-					t.Author.When.Month() == lastDays.Month() &&
-					t.Author.When.Year() == lastDays.Year() {
-					tagsPerDays[i] = append(tagsPerDays[i], t)
+		for _, tag := range tags {
+			if tag != nil {
+				if tag.Author.When.Day() == lastDays.Day() &&
+					tag.Author.When.Month() == lastDays.Month() &&
+					tag.Author.When.Year() == lastDays.Year() {
+					tagsPerDays[idx] = append(tagsPerDays[idx], tag)
 				}
 			}
 		}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -32,15 +32,15 @@ func GetCounter(name, namespace string) prometheus.Counter {
 }
 
 func GetCounterValue(name, namespace string) float64 {
-	m := &dto.Metric{}
+	metric := &dto.Metric{}
 
-	if err := GetCounter(name, namespace).Write(m); err != nil {
+	if err := GetCounter(name, namespace).Write(metric); err != nil {
 		log.Error(err)
 
 		return 0
 	}
 
-	return m.GetCounter().GetValue()
+	return metric.GetCounter().GetValue()
 }
 
 // RegisterPrometheusCounter register a new Counter of given name with help text.

--- a/scanner/bitbucket.go
+++ b/scanner/bitbucket.go
@@ -46,39 +46,43 @@ func (scanner BitBucketScanner) ScanGroupOfRepos(
 		return fmt.Errorf("can't list repositories in %s: %w", url.String(), err)
 	}
 
-	for _, r := range res.Items {
-		if r.Is_private {
-			log.Warnf("Skipping %s: repo is private", r.Full_name)
+	for _, item := range res.Items {
+		if item.Is_private {
+			log.Warnf("Skipping %s: repo is private", item.Full_name)
 
 			continue
 		}
 
 		opt := &bitbucket.RepositoryFilesOptions{
 			Owner:    owner,
-			RepoSlug: r.Slug,
-			Ref:      r.Mainbranch.Name,
+			RepoSlug: item.Slug,
+			Ref:      item.Mainbranch.Name,
 			Path:     "publiccode.yml",
 		}
 
-		res, err := scanner.client.Repositories.Repository.GetFileContent(opt)
+		fileContent, err := scanner.client.Repositories.Repository.GetFileContent(opt)
 		if err != nil {
-			log.Infof("[%s]: no publiccode.yml: %s", r.Full_name, err.Error())
+			log.Infof("[%s]: no publiccode.yml: %s", item.Full_name, err.Error())
 
 			continue
 		}
 
-		if res != nil {
-			u, err := url.Parse(fmt.Sprintf("https://bitbucket.org/%s/%s.git", owner, r.Slug))
+		if fileContent != nil {
+			repoURL, err := url.Parse(fmt.Sprintf("https://bitbucket.org/%s/%s.git", owner, item.Slug))
 			if err != nil {
 				return fmt.Errorf("failed to get canonical repo URL for %s: %w", url.String(), err)
 			}
 
+			rawURL := fmt.Sprintf(
+				"https://bitbucket.org/%s/%s/raw/%s/publiccode.yml",
+				owner, item.Slug, item.Mainbranch.Name,
+			)
 			repositories <- common.Repository{
-				Name:         r.Full_name,
-				FileRawURL:   fmt.Sprintf("https://bitbucket.org/%s/%s/raw/%s/publiccode.yml", owner, r.Slug, r.Mainbranch.Name),
-				URL:          *u,
-				CanonicalURL: *u,
-				GitBranch:    r.Mainbranch.Name,
+				Name:         item.Full_name,
+				FileRawURL:   rawURL,
+				URL:          *repoURL,
+				CanonicalURL: *repoURL,
+				GitBranch:    item.Mainbranch.Name,
 				Publisher:    publisher,
 			}
 		}

--- a/scanner/gitea.go
+++ b/scanner/gitea.go
@@ -24,12 +24,12 @@ func NewGiteaScanner() Scanner {
 
 type giteaRepo struct {
 	Name          string `json:"name"`
-	FullName      string `json:"full_name"`
+	FullName      string `json:"full_name"` //nolint:tagliatelle // Gitea API uses snake_case
 	Private       bool   `json:"private"`
 	Archived      bool   `json:"archived"`
-	DefaultBranch string `json:"default_branch"`
-	HTMLURL       string `json:"html_url"`
-	CloneURL      string `json:"clone_url"`
+	DefaultBranch string `json:"default_branch"` //nolint:tagliatelle // Gitea API uses snake_case
+	HTMLURL       string `json:"html_url"`       //nolint:tagliatelle // Gitea API uses snake_case
+	CloneURL      string `json:"clone_url"`      //nolint:tagliatelle // Gitea API uses snake_case
 	Empty         bool   `json:"empty"`
 }
 
@@ -40,11 +40,11 @@ type giteaSearchResult struct {
 // ScanGroupOfRepos scans a Gitea or Forgejo org/user represented by u,
 // or all public repos on the instance if u is a root URL.
 func (scanner GiteaScanner) ScanGroupOfRepos(
-	u url.URL, publisher common.Publisher, repositories chan common.Repository,
+	groupURL url.URL, publisher common.Publisher, repositories chan common.Repository,
 ) error {
-	log.Debugf("GiteaScanner.ScanGroupOfRepos(%s)", u.String())
+	log.Debugf("GiteaScanner.ScanGroupOfRepos(%s)", groupURL.String())
 
-	owner := strings.Trim(u.Path, "/")
+	owner := strings.Trim(groupURL.Path, "/")
 
 	const limit = 50
 
@@ -54,7 +54,7 @@ func (scanner GiteaScanner) ScanGroupOfRepos(
 	}
 
 	for page := 1; ; page++ {
-		repos, err := fetchPage(&u, owner, limit, page)
+		repos, err := fetchPage(&groupURL, owner, limit, page)
 		if err != nil {
 			return fmt.Errorf("GiteaScanner: %w", err)
 		}
@@ -73,28 +73,28 @@ func (scanner GiteaScanner) ScanGroupOfRepos(
 	return nil
 }
 
-// ScanRepo scans a single Gitea or Forgejo repository represented by u.
+// ScanRepo scans a single Gitea or Forgejo repository represented by repoURL.
 func (scanner GiteaScanner) ScanRepo(
-	u url.URL, publisher common.Publisher, repositories chan common.Repository,
+	repoURL url.URL, publisher common.Publisher, repositories chan common.Repository,
 ) error {
-	log.Debugf("GiteaScanner.ScanRepo(%s)", u.String())
+	log.Debugf("GiteaScanner.ScanRepo(%s)", repoURL.String())
 
-	repoPath := strings.TrimSuffix(strings.Trim(u.Path, "/"), ".git")
+	repoPath := strings.TrimSuffix(strings.Trim(repoURL.Path, "/"), ".git")
 
 	parts := strings.SplitN(repoPath, "/", 2)
 	if len(parts) != 2 {
-		return fmt.Errorf("GiteaScanner: invalid repo URL: %s", u.String())
+		return fmt.Errorf("GiteaScanner: invalid repo URL: %s", repoURL.String())
 	}
 
 	owner, repoName := parts[0], parts[1]
-	apiURL := fmt.Sprintf("%s://%s/api/v1/repos/%s/%s", u.Scheme, u.Host, owner, repoName)
+	apiURL := fmt.Sprintf("%s://%s/api/v1/repos/%s/%s", repoURL.Scheme, repoURL.Host, owner, repoName)
 
 	repo, err := giteaFetchRepo(apiURL)
 	if err != nil {
 		return fmt.Errorf("GiteaScanner: %w", err)
 	}
 
-	return addGiteaRepo(&u, repo, publisher, repositories)
+	return addGiteaRepo(&repoURL, repo, publisher, repositories)
 }
 
 func addGiteaRepo(

--- a/scanner/github.go
+++ b/scanner/github.go
@@ -128,7 +128,7 @@ func (scanner GitHubScanner) ScanGroupOfRepos(
 // publisher and, if it contains a publiccode.yml, sends it as a [common.Repository]
 // repositories channel.
 // It returns any error encountered if any, otherwise nil.
-func (scanner GitHubScanner) ScanRepo(
+func (scanner GitHubScanner) ScanRepo( //nolint:funlen // goto retry blocks can't be extracted
 	url url.URL, publisher common.Publisher, repositories chan common.Repository,
 ) error {
 	log.Debugf("GitHubScanner.ScanRepo(%s)", url.String())

--- a/scanner/gitlab.go
+++ b/scanner/gitlab.go
@@ -98,26 +98,26 @@ func (scanner GitLabScanner) ScanRepo(
 }
 
 // isGitlabGroup returns true if the API URL points to a group.
-func isGitlabGroup(u url.URL) bool {
+func isGitlabGroup(gitlabURL url.URL) bool {
 	return (
 	// Always assume it's a group if the projects are hosted on gitlab.com,
 	// because we only want to support groups (ie. not repos belonging to a user)
-	strings.ToLower(u.Hostname()) == "gitlab.com" ||
+	strings.ToLower(gitlabURL.Hostname()) == "gitlab.com" ||
 		// Assume an on-premise GitLab's URL is a group if the path is not the root
 		// path (/) or empty
-		len(u.Path) > 1)
+		len(gitlabURL.Path) > 1)
 }
 
 // generateGitlabRawURL returns the file Gitlab specific file raw url.
 func generateGitlabRawURL(baseURL, defaultBranch string) (string, error) {
-	u, err := url.Parse(baseURL)
+	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
 		return "", err
 	}
 
-	u.Path = path.Join(u.Path, "raw", defaultBranch, "publiccode.yml")
+	parsedURL.Path = path.Join(parsedURL.Path, "raw", defaultBranch, "publiccode.yml")
 
-	return u.String(), err
+	return parsedURL.String(), err
 }
 
 // addGroupProjects sends all the projects in a GitLab group, including all subgroups, to


### PR DESCRIPTION
Fixes #331.

Six linters from the TODO list in `.golangci.yaml` are now enabled:

- `goconst`, `tagliatelle`, `gocyclo`, `funlen` — no code changes needed
- `varnamelen` — rename short variable names across 10 files
- `nestif` — extract `upsertSoftware()` from `ProcessRepo` to flatten the if/else block

`cyclop` and `gocognit` remain in the TODO list: they require heavier refactoring of `ProcessRepo` and several scanner functions.