### PR TITLE
fix: GitHub token not picked up from config file

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -338,7 +338,7 @@ func (c *Crawler) ProcessRepo(repository common.Repository) { //nolint:funlen,go
 	domain := publiccode.Domain{
 		Host:        "github.com",
 		UseTokenFor: []string{"github.com", "api.github.com", "raw.githubusercontent.com"},
-		BasicAuth:   []string{os.Getenv("GITHUB_TOKEN")},
+		BasicAuth:   []string{viper.GetString("GITHUB_TOKEN")},
 	}
 
 	var parser *publiccode.Parser

--- a/scanner/github.go
+++ b/scanner/github.go
@@ -7,13 +7,13 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/google/go-github/v43/github"
 	"github.com/italia/publiccode-crawler/v4/common"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 )
 
@@ -27,7 +27,7 @@ type GitHubScanner struct {
 func NewGitHubScanner() Scanner {
 	ctx := context.Background()
 
-	token := os.Getenv("GITHUB_TOKEN")
+	token := viper.GetString("GITHUB_TOKEN")
 
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},


### PR DESCRIPTION
os.Getenv reads only from the process environment, not from config.toml. Using viper.GetString picks it up from both.