### PR TITLE
fix: org URLs were scanned as single repos

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -506,7 +506,7 @@ func (c *Crawler) scanSource(
 		)
 	}
 
-	if src.Group {
+	if src.Group || vcsurl.IsAccount(&src.URL) {
 		return host.lister.List(src.URL, publisher, repos)
 	}
 


### PR DESCRIPTION
When a source URL points to a GitHub org or GitLab group, vcsurl.IsAccount detects it and routes to ScanGroupOfRepos regardless of the Group field in the source config.