### PR TITLE
refactor: split CodeHosting and CatalogSource

### DIFF
--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -193,7 +193,7 @@ page:
 				driver = common.InferVCSDriver(*hostingURL)
 			}
 
-			publisher.Sources = append(publisher.Sources, common.CatalogSource{
+			publisher.Sources = append(publisher.Sources, common.CodeHosting{
 				URL:    *hostingURL,
 				Driver: driver,
 				Args:   args,

--- a/cmd/download_publishers.go
+++ b/cmd/download_publishers.go
@@ -62,7 +62,7 @@ var downloadPublishersCmd = &cobra.Command{
 				if publisher.ID == entry.IPA {
 					parsedURL, _ := url.Parse(entry.URL)
 					// If this Id is already known, append this URL to the existing item
-					publishers[idx].Sources = append(publisher.Sources, common.CatalogSource{
+					publishers[idx].Sources = append(publisher.Sources, common.CodeHosting{
 						URL:    *parsedURL,
 						Driver: common.InferVCSDriver(*parsedURL),
 						Group:  true,
@@ -77,7 +77,7 @@ var downloadPublishersCmd = &cobra.Command{
 			publishers = append(publishers, common.Publisher{
 				Name: entry.IPA,
 				ID:   entry.IPA,
-				Sources: []common.CatalogSource{{
+				Sources: []common.CodeHosting{{
 					URL:    *parsedURL,
 					Driver: common.InferVCSDriver(*parsedURL),
 					Group:  true,

--- a/common/catalog.go
+++ b/common/catalog.go
@@ -1,5 +1,18 @@
 package common
 
+import "net/url"
+
+// CatalogSource is one of a catalog's enumeration points. By definition a
+// source produces a list of repositories, so there is no Group flag.
+// Driver may be a code-host driver ("github", "gitlab", "bitbucket",
+// "gitea"), an enumeration driver ("json"), or an upstream API
+// ("software-catalog-api").
+type CatalogSource struct {
+	URL    url.URL
+	Driver string
+	Args   []string
+}
+
 type Catalog struct {
 	ID                  string
 	Name                string

--- a/common/publisher.go
+++ b/common/publisher.go
@@ -11,11 +11,10 @@ import (
 
 var fileReaderInject = os.ReadFile
 
-// CatalogSource is a single source of repository URLs.
-// Driver identifies the driver ("github", "gitlab", "bitbucket", "gitea", "json", ...).
-// Args holds positional arguments for the driver, e.g. a JSONPath expression for "json".
-// Group distinguishes org/group scans (true) from single-repo scans (false).
-type CatalogSource struct {
+// CodeHosting is one of a publisher's hosting locations. It may be a single
+// repository or an account/group (Group=true). Driver is one of "github",
+// "gitlab", "bitbucket", "gitea" — code-host scanners only.
+type CodeHosting struct {
 	URL    url.URL
 	Driver string
 	Args   []string
@@ -26,7 +25,7 @@ type Publisher struct {
 	ID            string
 	AlternativeID string
 	Name          string
-	Sources       []CatalogSource
+	Sources       []CodeHosting
 }
 
 // publisherYAML is the on-disk representation. Driver is inferred from the URL.
@@ -61,7 +60,7 @@ func LoadPublishers(path string) ([]Publisher, error) {
 
 		for _, org := range rawPub.Organizations {
 			stdURL := (url.URL)(org)
-			pub.Sources = append(pub.Sources, CatalogSource{
+			pub.Sources = append(pub.Sources, CodeHosting{
 				URL:    stdURL,
 				Driver: InferVCSDriver(stdURL),
 				Group:  true,
@@ -70,7 +69,7 @@ func LoadPublishers(path string) ([]Publisher, error) {
 
 		for _, repo := range rawPub.Repositories {
 			stdURL := (url.URL)(repo)
-			pub.Sources = append(pub.Sources, CatalogSource{
+			pub.Sources = append(pub.Sources, CodeHosting{
 				URL:    stdURL,
 				Driver: InferVCSDriver(stdURL),
 				Group:  false,

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -183,7 +183,7 @@ func (c *Crawler) ScanPublisher(publisher common.Publisher) {
 	defer c.publishersWg.Done()
 
 	for _, src := range publisher.Sources {
-		if err := c.scanSource(src, publisher, c.repositories); err != nil {
+		if err := c.scanCodeHosting(src, publisher, c.repositories); err != nil {
 			if errors.Is(err, scanner.ErrPubliccodeNotFound) {
 				log.Warnf("[%s] %s", src.URL.String(), err.Error())
 			} else {
@@ -243,7 +243,7 @@ func (c *Crawler) ScanCatalog(cat common.Catalog) {
 	}
 
 	for _, src := range cat.Sources {
-		if err := c.scanSource(src, publisher, proxyCh); err != nil {
+		if err := c.scanCatalogSource(src, publisher, proxyCh); err != nil {
 			if errors.Is(err, scanner.ErrPubliccodeNotFound) {
 				log.Warnf("[%s] %s", src.URL.String(), err.Error())
 			} else {
@@ -480,8 +480,40 @@ func (c *Crawler) ProcessRepo(repository common.Repository) { //nolint:funlen,go
 	}
 }
 
-// scanSource dispatches a single CatalogSource to the appropriate scanner.
-func (c *Crawler) scanSource(
+// scanCodeHosting dispatches a publisher's code hosting location. Group
+// distinguishes account/group scans from single-repo scans.
+func (c *Crawler) scanCodeHosting(
+	host common.CodeHosting, publisher common.Publisher, repos chan common.Repository,
+) error {
+	if host.Driver == "" {
+		return fmt.Errorf(
+			"%s: unrecognized platform for %s, skipping",
+			publisher.Name,
+			host.URL.String(),
+		)
+	}
+
+	vcs, ok := c.hosts[host.Driver]
+	if !ok {
+		return fmt.Errorf(
+			"%s: unknown code hosting driver %q for %s",
+			publisher.Name,
+			host.Driver,
+			host.URL.String(),
+		)
+	}
+
+	if host.Group {
+		return vcs.lister.List(host.URL, publisher, repos)
+	}
+
+	return vcs.scanner.Scan(host.URL, publisher, repos)
+}
+
+// scanCatalogSource dispatches a single catalog source. A source is always
+// a list of repositories: code-host drivers (github/gitlab/...) go through
+// List, the json driver enumerates URLs and recurses one-by-one.
+func (c *Crawler) scanCatalogSource(
 	src common.CatalogSource, publisher common.Publisher, repos chan common.Repository,
 ) error {
 	if src.Driver == "" {
@@ -496,7 +528,7 @@ func (c *Crawler) scanSource(
 		return c.scanJSONCatalog(src, publisher, repos)
 	}
 
-	host, ok := c.hosts[src.Driver]
+	vcs, ok := c.hosts[src.Driver]
 	if !ok {
 		return fmt.Errorf(
 			"%s: unknown catalog driver %q for %s",
@@ -506,15 +538,11 @@ func (c *Crawler) scanSource(
 		)
 	}
 
-	if src.Group {
-		return host.lister.List(src.URL, publisher, repos)
-	}
-
-	return host.scanner.Scan(src.URL, publisher, repos)
+	return vcs.lister.List(src.URL, publisher, repos)
 }
 
 // scanJSONCatalog enumerates repository URLs from a JSON catalog and dispatches
-// each one to the appropriate scanner.
+// each one as a single-repo code hosting entry.
 func (c *Crawler) scanJSONCatalog(
 	src common.CatalogSource, publisher common.Publisher, repos chan common.Repository,
 ) error {
@@ -534,13 +562,13 @@ func (c *Crawler) scanJSONCatalog(
 	}
 
 	for _, repoURL := range urls {
-		repoSrc := common.CatalogSource{
+		host := common.CodeHosting{
 			URL:    repoURL,
 			Driver: common.InferVCSDriver(repoURL),
 			Group:  false,
 		}
 
-		if err := c.scanSource(repoSrc, publisher, repos); err != nil {
+		if err := c.scanCodeHosting(host, publisher, repos); err != nil {
 			if errors.Is(err, scanner.ErrPubliccodeNotFound) {
 				log.Warnf("[%s] %s", repoURL.String(), err.Error())
 			} else {


### PR DESCRIPTION
A publisher's code hosting can be a single repo or a whole account/group, so it needs the Group flag. A catalog source is supposed to always have a list of repos so the flag is meaningless there.