### PR TITLE
revert: this didn't belong here

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(go build *)",
-      "Bash(go test *)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,3 @@ config.toml
 # Downloaded files
 cache
 data
-
-.claude/*

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -676,18 +676,7 @@ func validateFile(
 
 	expected := publishersNamespace + publisher.AlternativeID
 
-	// When no namespace is configured for this publisher, also accept the Italian PA
-	// URN format ("urn:x-italian-pa:<alternativeId>") as a valid match. Self-onboarded
-	// Italian PA publishers have no publishersNamespace in the crawler but their
-	// publiccode.yml legitimately declares the full URN.
-	//nolint:godox
-	// TODO: remove this fallback once publishers expose publishersNamespace via the API
-	// (https://github.com/italia/publiccode-crawler/issues/298)
-	italianPAExpected := "urn:x-italian-pa:" + publisher.AlternativeID
-
-	uri := strings.TrimSpace(organisationURI)
-	if !strings.EqualFold(strings.TrimSpace(expected), uri) &&
-		(publishersNamespace != "" || !strings.EqualFold(strings.TrimSpace(italianPAExpected), uri)) {
+	if !strings.EqualFold(strings.TrimSpace(expected), strings.TrimSpace(organisationURI)) {
 		return fmt.Errorf(
 			"organisation is '%s', but '%s' was expected for '%s' in %s",
 			organisationURI,

--- a/crawler/crawler_test.go
+++ b/crawler/crawler_test.go
@@ -116,21 +116,6 @@ func TestValidateFile_NoNamespaceMismatch(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// Self-onboarded Italian PA publishers have no publishersNamespace in the crawler
-// but their publiccode.yml declares the full URN — both forms must be accepted.
-func TestValidateFile_NoNamespaceMatchesItalianPAUrn(t *testing.T) {
-	pc := newPublicCode(t,
-		"https://github.com/foo/bar",
-		"urn:x-italian-pa:pcm",
-	)
-	publisher := common.Publisher{ID: "uuid-1234", AlternativeID: "pcm", Name: "PCM"}
-
-	err := validateFile("", publisher, pc,
-		"https://raw.githubusercontent.com/foo/bar/main/publiccode.yml")
-
-	assert.NoError(t, err)
-}
-
 func TestValidateFile_OrganisationMatchesPublisher(t *testing.T) {
 	pc := newPublicCode(t,
 		"https://github.com/foo/bar",


### PR DESCRIPTION
Reverts 0ee8c9b, 2341702, 110036d. No PR, three commits straight on main and LLM generated code with no oversight.