### PR TITLE
fix: update software auto-created as inactive

### DIFF
--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -296,7 +296,10 @@ func catalogPath(catalogID string, segments ...string) string {
 func (clt APIClient) GetCatalogSoftwareByURL(catalogID string, softwareURL string) (*Software, error) {
 	var softwareResponse SoftwarePaginated
 
-	reqURL := joinPath(clt.baseURL, catalogPath(catalogID, "software")) + "?url=" + softwareURL
+	// all=true makes the API return inactive software as well: without it
+	// software created as inactive is invisible to us and we'd try to
+	// create it again, failing on the duplicate URL.
+	reqURL := joinPath(clt.baseURL, catalogPath(catalogID, "software")) + "?all=true&url=" + softwareURL
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, reqURL, nil)
 	if err != nil {
@@ -359,12 +362,13 @@ func (clt APIClient) PostCatalogSoftware(
 
 // PatchCatalogSoftware updates a software resource within the given catalog.
 func (clt APIClient) PatchCatalogSoftware(
-	catalogID string, softwareID string, softwareURL string, aliases []string, publiccodeYml string,
+	catalogID string, softwareID string, softwareURL string, aliases []string, publiccodeYml string, active bool,
 ) error {
 	body, err := json.Marshal(map[string]any{
 		"publiccodeYml": publiccodeYml,
 		"url":           softwareURL,
 		"aliases":       aliases,
+		"active":        active,
 	})
 	if err != nil {
 		return fmt.Errorf("can't update software in catalog %s: %w", catalogID, err)
@@ -441,7 +445,10 @@ func (clt APIClient) GetSoftware(softwareID string) (*Software, error) {
 func (clt APIClient) GetSoftwareByURL(url string) (*Software, error) {
 	var softwareResponse SoftwarePaginated
 
-	reqURL := joinPath(clt.baseURL, "/software") + "?url=" + url
+	// all=true makes the API return inactive software as well: without it
+	// software created as inactive is invisible to us and we'd try to
+	// create it again, failing on the duplicate URL.
+	reqURL := joinPath(clt.baseURL, "/software") + "?all=true&url=" + url
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, reqURL, nil)
 	if err != nil {
@@ -504,12 +511,13 @@ func (clt APIClient) PostSoftware(url string, aliases []string, publiccodeYml st
 // PatchSoftware updates a software resource with the given fields and returns
 // any error encountered.
 func (clt APIClient) PatchSoftware(
-	softwareID string, url string, aliases []string, publiccodeYml string,
+	softwareID string, url string, aliases []string, publiccodeYml string, active bool,
 ) error {
 	body, err := json.Marshal(map[string]any{
 		"publiccodeYml": publiccodeYml,
 		"url":           url,
 		"aliases":       aliases,
+		"active":        active,
 	})
 	if err != nil {
 		return fmt.Errorf("can't update software: %w", err)

--- a/apiclient/apiclient_test.go
+++ b/apiclient/apiclient_test.go
@@ -1,0 +1,99 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) APIClient {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	viper.Set("API_BASEURL", server.URL)
+	viper.Set("API_BEARER_TOKEN", "token")
+
+	return NewClient()
+}
+
+func patchBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+
+	bytes, err := io.ReadAll(r.Body)
+	assert.NoError(t, err)
+
+	var fields map[string]any
+	assert.NoError(t, json.Unmarshal(bytes, &fields))
+
+	return fields
+}
+
+func TestGetSoftwareByURL_includesInactive(t *testing.T) {
+	var query string
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+
+		_, _ = w.Write([]byte(`{"data": [{"id": "id1", "active": false}], "links": {}}`))
+	})
+
+	software, err := client.GetSoftwareByURL("https://example.org/repo.git")
+
+	assert.NoError(t, err)
+	assert.Contains(t, query, "all=true")
+	assert.Equal(t, "id1", software.ID)
+	assert.False(t, software.Active)
+}
+
+func TestGetCatalogSoftwareByURL_includesInactive(t *testing.T) {
+	var query string
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+
+		_, _ = w.Write([]byte(`{"data": [{"id": "id1", "active": false}], "links": {}}`))
+	})
+
+	software, err := client.GetCatalogSoftwareByURL("catalog1", "https://example.org/repo.git")
+
+	assert.NoError(t, err)
+	assert.Contains(t, query, "all=true")
+	assert.Equal(t, "id1", software.ID)
+}
+
+func TestPatchSoftware_sendsActive(t *testing.T) {
+	var fields map[string]any
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		fields = patchBody(t, r)
+
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	err := client.PatchSoftware("id1", "https://example.org/repo.git", nil, "yml", true)
+
+	assert.NoError(t, err)
+	assert.Equal(t, true, fields["active"])
+}
+
+func TestPatchCatalogSoftware_sendsActive(t *testing.T) {
+	var fields map[string]any
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		fields = patchBody(t, r)
+
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	err := client.PatchCatalogSoftware("catalog1", "id1", "https://example.org/repo.git", nil, "yml", true)
+
+	assert.NoError(t, err)
+	assert.Equal(t, true, fields["active"])
+}

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -726,12 +726,27 @@ func (c *Crawler) upsertSoftware(
 
 	metrics.GetCounter("repository_known", c.Index).Inc()
 
+	// Software auto-created as inactive is only recognizable by its
+	// created_at being equal to updated_at (see the manual deactivation
+	// check in ProcessRepo). Patching it while publiccode.yml is still
+	// invalid would bump updated_at and make it look manually
+	// deactivated, locking it inactive forever, so leave it untouched.
+	if !valid && !software.Active {
+		return nil
+	}
+
+	// Re-activate software that was auto-created as inactive now that its
+	// publiccode.yml is valid. Manually deactivated software never gets
+	// this far, and active software is not deactivated on an invalid
+	// file.
+	active := valid || software.Active
+
 	if !c.DryRun {
 		if catalogID != "" {
-			return c.apiClient.PatchCatalogSoftware(catalogID, software.ID, repoURL, aliases, string(publiccodeYml))
+			return c.apiClient.PatchCatalogSoftware(catalogID, software.ID, repoURL, aliases, string(publiccodeYml), active)
 		}
 
-		return c.apiClient.PatchSoftware(software.ID, repoURL, aliases, string(publiccodeYml))
+		return c.apiClient.PatchSoftware(software.ID, repoURL, aliases, string(publiccodeYml), active)
 	}
 
 	return nil

--- a/crawler/crawler_test.go
+++ b/crawler/crawler_test.go
@@ -1,11 +1,17 @@
 package crawler
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
+	"github.com/italia/publiccode-crawler/v4/apiclient"
 	"github.com/italia/publiccode-crawler/v4/common"
 	publiccode "github.com/italia/publiccode-parser-go/v5"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -140,4 +146,72 @@ func TestValidateFile_OrganisationMismatch(t *testing.T) {
 		"https://raw.githubusercontent.com/foo/bar/main/publiccode.yml")
 
 	assert.Error(t, err)
+}
+
+func newTestCrawler(t *testing.T, handler http.HandlerFunc) *Crawler {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	viper.Set("API_BASEURL", server.URL)
+	viper.Set("API_BEARER_TOKEN", "token")
+
+	return &Crawler{Index: "test", apiClient: apiclient.NewClient()}
+}
+
+func TestUpsertSoftware_reactivatesOnValidFile(t *testing.T) {
+	var patched map[string]any
+
+	crawler := newTestCrawler(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+
+		bytes, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.NoError(t, json.Unmarshal(bytes, &patched))
+
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	software := &apiclient.Software{ID: "id1", Active: false}
+	err := crawler.upsertSoftware("", software, "https://example.org/repo.git", nil, []byte("yml"), true)
+
+	assert.NoError(t, err)
+	assert.Equal(t, true, patched["active"])
+}
+
+func TestUpsertSoftware_skipsInactiveWithInvalidFile(t *testing.T) {
+	requests := 0
+
+	crawler := newTestCrawler(t, func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	software := &apiclient.Software{ID: "id1", Active: false}
+	err := crawler.upsertSoftware("", software, "https://example.org/repo.git", nil, []byte("yml"), false)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, requests)
+}
+
+func TestUpsertSoftware_keepsActiveOnInvalidFile(t *testing.T) {
+	var patched map[string]any
+
+	crawler := newTestCrawler(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+
+		bytes, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.NoError(t, json.Unmarshal(bytes, &patched))
+
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	software := &apiclient.Software{ID: "id1", Active: true}
+	err := crawler.upsertSoftware("", software, "https://example.org/repo.git", nil, []byte("yml"), false)
+
+	assert.NoError(t, err)
+	assert.Equal(t, true, patched["active"])
 }


### PR DESCRIPTION
The API hides inactive software unless all=true is passed, so the lookup by url came back empty for software auto-created as inactive and we tried to POST it again, failing on the duplicate URL.

Also send the active flag on update when publiccode.yml is valid, so software created inactive gets activated once the file is fixed, and skip the update entirely while it's still invalid: the PATCH would bump updated_at, which is how we tell auto-created inactive software from manually deactivated one.

Fix #596.