### PR TITLE
ci: add a cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:
@@ -13,7 +15,13 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      # Our own libraries: we control what goes into them, and a fix there
+      # is usually the reason for the release, so waiting a week defeats it.
+      exclude:
+        - "github.com/italia/*"
     groups:
       go-deps:
         patterns:


### PR DESCRIPTION
A week between an upstream release and the PR that pulls it in, so a
compromised release has a window to be caught. publiccode-parser-go
and httpclient-lib-go are ours and skip the wait, since a fix there is
usually why the release happened. Go updates move to weekly to match:
with the cooldown in place, daily polling only produced noise.
