### PR TITLE
ci: make the release build reproducible and check it

### DIFF
--- a/.github/workflows/reproducibility.yml
+++ b/.github/workflows/reproducibility.yml
@@ -1,0 +1,50 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  reproducibility:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # goreleaser and the ldflags below read the tag and commit history
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
+        with:
+          version: v2.15.2
+          install-only: true
+      - name: Build the release artifact with goreleaser
+        run: goreleaser build --snapshot --clean --single-target -o /tmp/goreleaser-build
+        env:
+          # The newest tag may well be a helm/* one, which goreleaser
+          # cannot parse as semver.
+          GORELEASER_CURRENT_TAG: v0.0.0
+
+      - name: Rebuild from source and compare digests
+        run: |
+          MODULE=github.com/italia/publiccode-crawler/v4/internal
+          VERSION=$(jq -r .version dist/metadata.json)
+          DATE=$(git log -1 --format=%cd --date=format-local:'%Y-%m-%dT%H:%M:%SZ')
+          cp -a . /tmp/src-elsewhere
+          cd /tmp/src-elsewhere
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOAMD64=v1 \
+            go build -trimpath \
+              -ldflags="-s -w -buildid= -X $MODULE.VERSION=$VERSION -X $MODULE.BuildTime=$DATE" \
+              -o /tmp/plain-build ./main.go
+          sha256sum /tmp/goreleaser-build /tmp/plain-build
+          cmp /tmp/goreleaser-build /tmp/plain-build \
+            && echo "Reproducible build confirmed"
+        env:
+          TZ: UTC

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,8 +8,10 @@ builds:
   id: crawler
   binary: crawler
   main: ./main.go
+  flags:
+    - -trimpath
   ldflags:
-    - -s -w -X github.com/italia/publiccode-crawler/v4/internal.VERSION={{.Version}} -X github.com/italia/publiccode-crawler/v4/internal.BuildTime={{.Date}}
+    - -s -w -buildid= -X github.com/italia/publiccode-crawler/v4/internal.VERSION={{.Version}} -X github.com/italia/publiccode-crawler/v4/internal.BuildTime={{.CommitDate}}
   env:
   - CGO_ENABLED=0
   hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.25@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb59733
 
 WORKDIR /src
 COPY . .
-RUN go build -ldflags "-s -w -X 'github.com/italia/publiccode-crawler/v4/internal.VERSION=$(git describe --abbrev=0 --tags)' -X 'github.com/italia/publiccode-crawler/v4/internal.BuildTime=$(date)'"
+RUN go build -trimpath -ldflags "-s -w -buildid= -X 'github.com/italia/publiccode-crawler/v4/internal.VERSION=$(git describe --abbrev=0 --tags)' -X 'github.com/italia/publiccode-crawler/v4/internal.BuildTime=$(git log -1 --format=%cd --date=format-local:%Y-%m-%dT%H:%M:%SZ)'"
 
 FROM alpine:3@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 


### PR DESCRIPTION
The binary carried the wall clock at build time, so no two builds of
the same commit could ever match. It now carries the commit date, is
built with -trimpath and a cleared build id, and a workflow rebuilds
the artifact from a copy of the source elsewhere on disk and compares
digests.
