### PR TITLE
ci: check the module cache against go.sum before the tests

### DIFF
--- a/.github/workflows/test_and_publish_docker_image.yml
+++ b/.github/workflows/test_and_publish_docker_image.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go build
+      - run: go mod verify
       - run: go test -race ./...
       - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:


### PR DESCRIPTION
The test job downloaded the dependencies and ran straight into the
suite, so a module whose content no longer matched its recorded hash
would only surface as a confusing compile.
