### PR TITLE
chore: enable the wsl_v5 linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,9 +48,6 @@ linters:
     # Scanner constructors return Scanner by design
     - ireturn
 
-    # Same as wsl above, v2 version
-    - wsl_v5
-
     # TODO: fix and enable these
     - cyclop
     - gocognit

--- a/apiclient/apiclient.go
+++ b/apiclient/apiclient.go
@@ -183,8 +183,10 @@ page:
 				return nil, fmt.Errorf("can't parse GET %s response: %w", reqURL, err)
 			}
 
-			var driver string
-			var args []string
+			var (
+				driver string
+				args   []string
+			)
 
 			if len(hosting.Type) > 0 {
 				driver = hosting.Type[0]

--- a/catalog/json.go
+++ b/catalog/json.go
@@ -47,6 +47,7 @@ func (c *JSONDriver) Enumerate(ctx context.Context, catalogURL url.URL) ([]url.U
 	}
 
 	var rawURLs []any
+
 	switch v := result.(type) {
 	case []any:
 		rawURLs = v

--- a/cmd/download_publishers.go
+++ b/cmd/download_publishers.go
@@ -31,6 +31,7 @@ var downloadPublishersCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(2),
 	Run: func(_ *cobra.Command, args []string) {
 		var publishers []common.Publisher
+
 		if _, err := os.Stat(args[1]); err == nil {
 			data, err := os.ReadFile(args[1])
 			if err != nil {
@@ -45,12 +46,14 @@ var downloadPublishersCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		defer resp.Body.Close()
+
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		var repolist repolistType
+
 		err = yaml.Unmarshal(bodyBytes, &repolist)
 		if err != nil {
 			log.Fatal(err)
@@ -91,10 +94,12 @@ var downloadPublishersCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		defer outFile.Close()
+
 		data, err := yaml.Marshal(publishers)
 		if err != nil {
 			log.Fatal(err)
 		}
+
 		if _, err = outFile.Write(data); err != nil {
 			log.Fatal(err)
 		}

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -232,6 +232,7 @@ func (c *Crawler) ScanCatalog(cat common.Catalog) {
 	proxyWg.Go(func() {
 		for repo := range proxyCh {
 			repo.CatalogID = cat.ID
+
 			repo.PublishersNamespace = cat.PublishersNamespace
 			c.repositories <- repo
 		}
@@ -270,8 +271,10 @@ func (c *Crawler) ProcessRepositories(repos chan common.Repository) {
 func (c *Crawler) ProcessRepo(repository common.Repository) { //nolint:funlen,gocyclo,maintidx
 	var logEntries []string
 
-	var software *apiclient.Software
-	var err error
+	var (
+		software *apiclient.Software
+		err      error
+	)
 
 	defer func() {
 		for _, e := range logEntries {
@@ -346,6 +349,7 @@ func (c *Crawler) ProcessRepo(repository common.Repository) { //nolint:funlen,go
 				"[%s] failed to fetch publiccode.yml (HTTP %d): %v",
 				repository.Name, resp.Status.Code, err,
 			))
+
 			metrics.GetCounter("repository_fetch_failed", c.Index).Inc()
 		}
 
@@ -382,6 +386,7 @@ func (c *Crawler) ProcessRepo(repository common.Repository) { //nolint:funlen,go
 	}
 
 	var parsed publiccode.PublicCode
+
 	parsed, err = parser.Parse(repository.FileRawURL)
 
 	valid := true
@@ -414,9 +419,11 @@ func (c *Crawler) ProcessRepo(repository common.Repository) { //nolint:funlen,go
 
 	if valid {
 		logEntries = append(logEntries, fmt.Sprintf("[%s] GOOD publiccode.yml\n", repository.Name))
+
 		metrics.GetCounter("repository_good_publiccodeyml", c.Index).Inc()
 	} else {
 		logEntries = append(logEntries, fmt.Sprintf("[%s] BAD publiccode.yml: %+v\n", repository.Name, err))
+
 		metrics.GetCounter("repository_bad_publiccodeyml", c.Index).Inc()
 	}
 

--- a/git/clone_repository.go
+++ b/git/clone_repository.go
@@ -110,6 +110,7 @@ type dayData struct {
 
 func buildVitalityCache(repository *gogit.Repository, existing *vitality.Cache) (vitality.Cache, error) {
 	var cache vitality.Cache
+
 	cache.LastUpdated = time.Now().UTC()
 
 	authorIndex := map[string]uint16{}

--- a/git/repo_activity.go
+++ b/git/repo_activity.go
@@ -64,6 +64,7 @@ func CalculateRepoActivity(repository common.Repository, days int, now time.Time
 		cutoff := now.AddDate(0, 0, -idx)
 
 		authorSet := map[uint16]struct{}{}
+
 		var commits, merges float64
 
 		cur := cache.FirstEntryDate
@@ -74,6 +75,7 @@ func CalculateRepoActivity(repository common.Repository, days int, now time.Time
 					authorSet[id] = struct{}{}
 				}
 			}
+
 			if sameDay(cur, cutoff) {
 				commits = float64(entry.Commits)
 				merges = float64(entry.Merges)
@@ -81,6 +83,7 @@ func CalculateRepoActivity(repository common.Repository, days int, now time.Time
 		}
 
 		var tagCount float64
+
 		cur = cache.FirstEntryDate
 		for _, tag := range cache.Tags {
 			cur = cur.AddDate(0, 0, int(tag.Delta))

--- a/git/vitality/codec.go
+++ b/git/vitality/codec.go
@@ -43,6 +43,7 @@ func daysToTime(days uint16) time.Time {
 
 func Marshal(cache Cache) ([]byte, error) {
 	var buf bytes.Buffer
+
 	write := func(v any) { binary.Write(&buf, binary.LittleEndian, v) } //nolint:errcheck
 
 	buf.WriteByte(version)
@@ -56,6 +57,7 @@ func Marshal(cache Cache) ([]byte, error) {
 	}
 
 	write(uint16(len(cache.Authors))) //nolint:gosec // bounded above
+
 	for _, author := range cache.Authors {
 		buf.WriteString(author)
 		buf.WriteByte(0)
@@ -66,6 +68,7 @@ func Marshal(cache Cache) ([]byte, error) {
 	}
 
 	write(uint16(len(cache.Tags))) //nolint:gosec // bounded above
+
 	for _, tag := range cache.Tags {
 		if tag.Delta > 65535 || tag.Count > 65535 {
 			return nil, fmt.Errorf("vitality marshal: tag delta %d or count %d out of range", tag.Delta, tag.Count)
@@ -80,6 +83,7 @@ func Marshal(cache Cache) ([]byte, error) {
 	}
 
 	write(uint16(len(cache.Entries))) //nolint:gosec // bounded above
+
 	for _, entry := range cache.Entries {
 		if entry.Delta > 65535 || entry.Commits > 65535 || entry.Merges > 65535 {
 			return nil, fmt.Errorf("vitality marshal: entry out of range (delta=%d commits=%d merges=%d)",
@@ -95,6 +99,7 @@ func Marshal(cache Cache) ([]byte, error) {
 		}
 
 		write(uint16(len(entry.Authors))) //nolint:gosec // bounded above
+
 		for _, author := range entry.Authors {
 			write(author)
 		}


### PR DESCRIPTION
wsl was disabled as deprecated and wsl_v5 went with it, while the
other publiccode repos run wsl_v5. Turn it on and apply its auto fix.
